### PR TITLE
fix validation

### DIFF
--- a/BlazorHero.CleanArchitecture/Client/Pages/Identity/RegisterUserModal.razor
+++ b/BlazorHero.CleanArchitecture/Client/Pages/Identity/RegisterUserModal.razor
@@ -1,5 +1,7 @@
 ﻿@inject Microsoft.Extensions.Localization.IStringLocalizer<RegisterUserModal> localizer
-<MudForm @ref="form" @bind-IsValid="@success" @bind-Errors="@errors">
+
+<EditForm Model="Model">
+    <DataAnnotationsValidator />
     <MudDialog>
         <TitleContent>
             @{
@@ -10,21 +12,21 @@
             }
         </TitleContent>
         <DialogContent>
-            <MudTextField For="@(() => UserName)" @bind-Value="UserName" Required="true" Label="@localizer["User Name"]" />
-            <MudTextField For="@(() => FirstName)" @bind-Value="FirstName" Required="true" Label="@localizer["First Name"]" />
-            <MudTextField For="@(() => LastName)" @bind-Value="LastName" Required="true" Label="@localizer["Last Name"]" />
-            <MudTextField For="@(() => Email)" InputType="InputType.Email" Required="true" @bind-Value="Email" Label="@localizer["Email"]" />
-            <MudTextField For="@(() => PhoneNumber)" @bind-Value="PhoneNumber" Required="true" Label="@localizer["Phone Number"]" />
-            <MudTextField For="@(() => Password)" InputType="@PasswordInput" Adornment="Adornment.End" AdornmentIcon="@PasswordInputIcon" OnAdornmentClick="TogglePasswordVisibility" @ref="pwField" Validation="@(new Func<string, IEnumerable<string>>(PasswordStrength))" @bind-Value="Password" Required="true" Label="@localizer["Password"]" />
-            <MudTextField For="@(() => ConfirmPassword)" Validation="@(new Func<string, string>(PasswordMatch))" InputType="InputType.Password" Required="true" @bind-Value="ConfirmPassword" Label="@localizer["Confirm Password"]" />
-            <MudCheckBox @bind-Checked="@ActivateUser" Label="@localizer["Activate User?"]" Color="Color.Primary"></MudCheckBox>
-            <MudCheckBox @bind-Checked="@AutoConfirmEmail" Label="@localizer["Auto Confirm Email?"]" Color="Color.Primary"></MudCheckBox>
+            <MudTextField For="@(() =>Model.UserName)" @bind-Value="Model.UserName" Required="true" Label="@localizer["User Name"]" HelperText="Min. of 6 characters" />
+            <MudTextField For="@(() => Model.FirstName)" @bind-Value="Model.FirstName" Required="true" Label="@localizer["First Name"]" />
+            <MudTextField For="@(() => Model.LastName)" @bind-Value="Model.LastName" Required="true" Label="@localizer["Last Name"]" />
+            <MudTextField For="@(() => Model.Email)" InputType="InputType.Email" Required="true" @bind-Value="Model.Email" Label="@localizer["Email"]" />
+            <MudTextField For="@(() => Model.PhoneNumber)" @bind-Value="Model.PhoneNumber" Required="true" Label="@localizer["Phone Number"]" />
+            <MudTextField For="@(() => Model.Password)" InputType="@PasswordInput" Adornment="Adornment.End" AdornmentIcon="@PasswordInputIcon" OnAdornmentClick="TogglePasswordVisibility" @ref="pwField" Validation="@(new Func<string, IEnumerable<string>>(PasswordStrength))" @bind-Value="Model.Password" Required="true" Label="@localizer["Password"]" />
+            <MudTextField For="@(() => Model.ConfirmPassword)" Validation="@(new Func<string, string>(PasswordMatch))" InputType="InputType.Password" Required="true" @bind-Value="Model.ConfirmPassword" Label="@localizer["Confirm Password"]" />
+            <MudCheckBox @bind-Checked="@Model.ActivateUser" Label="@localizer["Activate User?"]" Color="Color.Primary"></MudCheckBox>
+            <MudCheckBox @bind-Checked="@Model.AutoConfirmEmail" Label="@localizer["Auto Confirm Email?"]" Color="Color.Primary"></MudCheckBox>
         </DialogContent>
         <DialogActions>
             <MudButton Variant="Variant.Filled" OnClick="Cancel">@localizer["Cancel"]</MudButton>
             @{
-                <MudButton Variant="Variant.Filled" OnClick="SaveAsync" Color="Color.Success">@localizer["Register"]</MudButton>
+                <MudButton Variant="Variant.Filled" OnClick="OnValidSubmit" Color="Color.Success">@localizer["Register"]</MudButton>
             }
         </DialogActions>
     </MudDialog>
-</MudForm>
+</EditForm>

--- a/BlazorHero.CleanArchitecture/Client/Pages/Identity/RegisterUserModal.razor.cs
+++ b/BlazorHero.CleanArchitecture/Client/Pages/Identity/RegisterUserModal.razor.cs
@@ -1,7 +1,6 @@
 ﻿using BlazorHero.CleanArchitecture.Application.Requests.Identity;
 using Microsoft.AspNetCore.Components;
 using MudBlazor;
-using System;
 using System.Collections.Generic;
 using System.ComponentModel.DataAnnotations;
 using System.Text.RegularExpressions;
@@ -11,79 +10,45 @@ namespace BlazorHero.CleanArchitecture.Client.Pages.Identity
 {
     public partial class RegisterUserModal
     {
-        private bool success;
-        private string[] errors = { };
-        private MudForm form;
+        private RegisterUserModel Model { get; set; } = new RegisterUserModel();
 
-        [Parameter]
-        [Required]
-        [MinLength(6)]
-        public string UserName { get; set; }
-
-        [Parameter]
-        [Required]
-        public string FirstName { get; set; }
-
-        [Parameter]
-        [Required]
-        public string LastName { get; set; }
-
-        [Parameter]
-        [Required]
-        [EmailAddress]
-        public string Email { get; set; }
-
-        [Parameter]
-        [Required]
-        public string Password { get; set; }
-
-        [Parameter]
-        [Required]
-        public string ConfirmPassword { get; set; }
-
-        [Parameter]
-        public string PhoneNumber { get; set; }
-
-        public bool ActivateUser { get; set; }
-        public bool AutoConfirmEmail { get; set; }
         [CascadingParameter] private MudDialogInstance MudDialog { get; set; }
 
-        public void Cancel()
+        private void Cancel()
         {
             MudDialog.Cancel();
         }
-        private async Task SaveAsync()
+
+        private async Task OnValidSubmit()
         {
-            form.Validate();
-            if (form.IsValid)
+            var request = new RegisterRequest()
             {
-                var request = new RegisterRequest()
+                Email = Model.Email,
+                UserName = Model.UserName,
+                FirstName = Model.FirstName,
+                LastName = Model.LastName,
+                Password = Model.Password,
+                ConfirmPassword = Model.ConfirmPassword,
+                PhoneNumber = Model.PhoneNumber,
+                ActivateUser = Model.ActivateUser,
+                AutoConfirmEmail = Model.AutoConfirmEmail
+            };
+
+            var response = await _userManager.RegisterUserAsync(request);
+            if (response.Succeeded)
+            {
+                _snackBar.Add(localizer[response.Messages[0]], Severity.Success);
+                MudDialog.Close();
+            }
+            else
+            {
+                foreach (var message in response.Messages)
                 {
-                    Email = Email,
-                    UserName = UserName,
-                    FirstName = FirstName,
-                    LastName = LastName,
-                    Password = Password,
-                    ConfirmPassword = ConfirmPassword,
-                    PhoneNumber = PhoneNumber,
-                    ActivateUser = ActivateUser,
-                    AutoConfirmEmail = AutoConfirmEmail
-                };
-                var response = await _userManager.RegisterUserAsync(request);
-                if (response.Succeeded)
-                {
-                    _snackBar.Add(localizer[response.Messages[0]], Severity.Success);
-                    MudDialog.Close();
-                }
-                else
-                {
-                    foreach (var message in response.Messages)
-                    {
-                        _snackBar.Add(localizer[message], Severity.Error);
-                    }
+                    _snackBar.Add(localizer[message], Severity.Error);
                 }
             }
         }
+
         private IEnumerable<string> PasswordStrength(string pw)
         {
             if (string.IsNullOrWhiteSpace(pw))
@@ -91,6 +56,7 @@ namespace BlazorHero.CleanArchitecture.Client.Pages.Identity
                 yield return "Password is required!";
                 yield break;
             }
+
             if (pw.Length < 8)
                 yield return "Password must be at least of length 8";
             if (!Regex.IsMatch(pw, @"[A-Z]"))
@@ -129,5 +95,27 @@ namespace BlazorHero.CleanArchitecture.Client.Pages.Identity
                 PasswordInput = InputType.Text;
             }
         }
+
+        private class RegisterUserModel
+        {
+            [Parameter] [Required] [MinLength(6)] public string UserName { get; set; }
+
+            [Parameter] [Required] public string FirstName { get; set; }
+
+            [Parameter] [Required] public string LastName { get; set; }
+
+            [Parameter] [Required] [EmailAddress] public string Email { get; set; }
+
+            [Parameter] [Required] public string Password { get; set; }
+
+            [Parameter] [Required] public string ConfirmPassword { get; set; }
+
+            [Parameter] public string PhoneNumber { get; set; }
+
+            public bool ActivateUser { get; set; }
+            public bool AutoConfirmEmail { get; set; }
+        }
     }
+
+
 }


### PR DESCRIPTION
Changed the parent to EditForm.  MudBlazor's input components support Blazor's form validation if you put them into an `<EditForm>`

Extracted the `Model` out from the `Modal` (easy to get that one mixed up!) to it own private class.

I think this is the easiest path to take for any dialogs or forms that want to use the data annotations to drive validation.