### PR TITLE
Fixed  User Service GetRolesAsync error

### DIFF
--- a/BlazorHero.CleanArchitecture.Infrastructure/Services/Identity/UserService.cs
+++ b/BlazorHero.CleanArchitecture.Infrastructure/Services/Identity/UserService.cs
@@ -1,25 +1,25 @@
-﻿using AutoMapper;
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Text.Encodings.Web;
+using System.Threading.Tasks;
+using AutoMapper;
 using BlazorHero.CleanArchitecture.Application.Exceptions;
+using BlazorHero.CleanArchitecture.Application.Extensions;
 using BlazorHero.CleanArchitecture.Application.Interfaces.Services;
 using BlazorHero.CleanArchitecture.Application.Interfaces.Services.Identity;
-using BlazorHero.CleanArchitecture.Infrastructure.Models.Identity;
 using BlazorHero.CleanArchitecture.Application.Requests.Identity;
 using BlazorHero.CleanArchitecture.Application.Requests.Mail;
 using BlazorHero.CleanArchitecture.Application.Responses.Identity;
+using BlazorHero.CleanArchitecture.Infrastructure.Models.Identity;
+using BlazorHero.CleanArchitecture.Infrastructure.Specifications;
 using BlazorHero.CleanArchitecture.Shared.Constants.Role;
 using BlazorHero.CleanArchitecture.Shared.Wrapper;
 using Hangfire;
 using Microsoft.AspNetCore.Identity;
 using Microsoft.AspNetCore.WebUtilities;
 using Microsoft.EntityFrameworkCore;
-using System;
-using System.Collections.Generic;
-using System.Linq;
-using System.Text;
-using System.Text.Encodings.Web;
-using System.Threading.Tasks;
-using BlazorHero.CleanArchitecture.Application.Extensions;
-using BlazorHero.CleanArchitecture.Infrastructure.Specifications;
 using Microsoft.Extensions.Localization;
 
 namespace BlazorHero.CleanArchitecture.Infrastructure.Services.Identity
@@ -154,7 +154,9 @@ namespace BlazorHero.CleanArchitecture.Infrastructure.Services.Identity
         {
             var viewModel = new List<UserRoleModel>();
             var user = await _userManager.FindByIdAsync(userId);
-            foreach (var role in _roleManager.Roles)
+            var roles = await _roleManager.Roles.ToListAsync();
+
+            foreach (var role in roles)
             {
                 var userRolesViewModel = new UserRoleModel
                 {


### PR DESCRIPTION
when I Clicked on manage a user's Roles ,the user Role managed paged failed,  the  user Service method that gets a user's roles was failing because  it had a  foreach method which was iterating over a query this resulted.