### PR TITLE
Fix: Fix saving AuditEntry when modify the auditable Entity

### DIFF
--- a/BlazorHero.CleanArchitecture.Infrastructure/Contexts/AuditableContext.cs
+++ b/BlazorHero.CleanArchitecture.Infrastructure/Contexts/AuditableContext.cs
@@ -12,7 +12,7 @@ namespace BlazorHero.CleanArchitecture.Infrastructure.Contexts
 {
     public abstract class AuditableContext : IdentityDbContext<BlazorHeroUser, BlazorHeroRole, string, IdentityUserClaim<string>, IdentityUserRole<string>, IdentityUserLogin<string>, BlazorHeroRoleClaim, IdentityUserToken<string>>
     {
-        public AuditableContext(DbContextOptions options) : base(options)
+        protected AuditableContext(DbContextOptions options) : base(options)
         {
         }
 
@@ -69,7 +69,7 @@ namespace BlazorHero.CleanArchitecture.Infrastructure.Contexts
                             break;
 
                         case EntityState.Modified:
-                            if (property.IsModified)
+                            if (property.IsModified && property.OriginalValue?.Equals(property.CurrentValue) == false)
                             {
                                 auditEntry.ChangedColumns.Add(propertyName);
                                 auditEntry.AuditType = AuditType.Update;


### PR DESCRIPTION
* Fix saving `AuditEntry` when modify the some auditable Entity:

![image](https://user-images.githubusercontent.com/29679226/120369609-2f992b80-c31c-11eb-94a3-56f17f3024e1.png)
