### PR TITLE
Fix: Add validation that barcode already exists when creating the product

### DIFF
--- a/BlazorHero.CleanArchitecture.Application/Features/Products/Commands/AddEdit/AddEditProductCommand.cs
+++ b/BlazorHero.CleanArchitecture.Application/Features/Products/Commands/AddEdit/AddEditProductCommand.cs
@@ -9,6 +9,8 @@ using MediatR;
 using System.Threading;
 using System.Threading.Tasks;
 using Microsoft.Extensions.Localization;
+using System.Linq;
+using Microsoft.EntityFrameworkCore;
 
 namespace BlazorHero.CleanArchitecture.Application.Features.Products.Commands.AddEdit
 {
@@ -46,6 +48,12 @@ namespace BlazorHero.CleanArchitecture.Application.Features.Products.Commands.Ad
 
         public async Task<Result<int>> Handle(AddEditProductCommand command, CancellationToken cancellationToken)
         {
+            if (await _unitOfWork.Repository<Product>().Entities.Where(p => p.Id != command.Id)
+                .AnyAsync(p => p.Barcode == command.Barcode, cancellationToken))
+            {
+                return await Result<int>.FailAsync(_localizer["Barcode already exists."]);
+            }
+
             var uploadRequest = command.UploadRequest;
             if (uploadRequest != null)
             {

--- a/BlazorHero.CleanArchitecture.Application/Resources/Features/Products/Commands/AddEdit/AddEditProductCommandHandler.en.resx
+++ b/BlazorHero.CleanArchitecture.Application/Resources/Features/Products/Commands/AddEdit/AddEditProductCommandHandler.en.resx
@@ -117,6 +117,9 @@
   <resheader name="writer">
     <value>System.Resources.ResXResourceWriter, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
   </resheader>
+  <data name="Barcode already exists." xml:space="preserve">
+    <value>Barcode already exists.</value>
+  </data>
   <data name="Product Not Found!" xml:space="preserve">
     <value>Product Not Found!</value>
   </data>

--- a/BlazorHero.CleanArchitecture.Application/Resources/Features/Products/Commands/AddEdit/AddEditProductCommandHandler.it.resx
+++ b/BlazorHero.CleanArchitecture.Application/Resources/Features/Products/Commands/AddEdit/AddEditProductCommandHandler.it.resx
@@ -117,6 +117,9 @@
   <resheader name="writer">
     <value>System.Resources.ResXResourceWriter, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
   </resheader>
+  <data name="Barcode already exists." xml:space="preserve">
+    <value>Barcode already exists.</value>
+  </data>
   <data name="Product Not Found!" xml:space="preserve">
     <value>Prodotto Non Trovato!</value>
   </data>

--- a/BlazorHero.CleanArchitecture.Application/Resources/Features/Products/Commands/AddEdit/AddEditProductCommandHandler.km.resx
+++ b/BlazorHero.CleanArchitecture.Application/Resources/Features/Products/Commands/AddEdit/AddEditProductCommandHandler.km.resx
@@ -117,6 +117,9 @@
   <resheader name="writer">
     <value>System.Resources.ResXResourceWriter, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
   </resheader>
+  <data name="Barcode already exists." xml:space="preserve">
+    <value>Barcode already exists.</value>
+  </data>
   <data name="Product Not Found!" xml:space="preserve">
     <value>ផលិតផលរកមិនឃើញ!</value>
   </data>

--- a/BlazorHero.CleanArchitecture.Application/Resources/Features/Products/Commands/AddEdit/AddEditProductCommandHandler.ru.resx
+++ b/BlazorHero.CleanArchitecture.Application/Resources/Features/Products/Commands/AddEdit/AddEditProductCommandHandler.ru.resx
@@ -117,6 +117,9 @@
   <resheader name="writer">
     <value>System.Resources.ResXResourceWriter, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
   </resheader>
+  <data name="Barcode already exists." xml:space="preserve">
+    <value>Баркод уже существует.</value>
+  </data>
   <data name="Product Not Found!" xml:space="preserve">
     <value>Продукт не найден!</value>
   </data>


### PR DESCRIPTION
* Add validation that barcode already exists when creating the `Product`:

![image](https://user-images.githubusercontent.com/29679226/120386194-ffa85300-c330-11eb-9a45-e7b78d496dec.png)