### PR TITLE
Feature Request #136: Enable BlazorHero client code to run in Blazor Server mode

### DIFF
--- a/BlazorHero.CleanArchitecture.Client.Infrastructure/Authentication/AuthenticationHeaderHandler.cs
+++ b/BlazorHero.CleanArchitecture.Client.Infrastructure/Authentication/AuthenticationHeaderHandler.cs
@@ -18,14 +18,21 @@ namespace BlazorHero.CleanArchitecture.Client.Infrastructure.Authentication
             HttpRequestMessage request,
             CancellationToken cancellationToken)
         {
-            if (request.Headers.Authorization?.Scheme != "Bearer")
+            try
             {
-                var savedToken = await this.localStorage.GetItemAsync<string>(StorageConstants.Local.AuthToken);
-
-                if (!string.IsNullOrWhiteSpace(savedToken))
+                if (request.Headers.Authorization?.Scheme != "Bearer")
                 {
-                    request.Headers.Authorization = new AuthenticationHeaderValue("Bearer", savedToken);
+                    var savedToken = await this.localStorage.GetItemAsync<string>(StorageConstants.Local.AuthToken);
+
+                    if (!string.IsNullOrWhiteSpace(savedToken))
+                    {
+                        request.Headers.Authorization = new AuthenticationHeaderValue("Bearer", savedToken);
+                    }
                 }
+            }
+            catch
+            {
+
             }
 
             return await base.SendAsync(request, cancellationToken);

--- a/BlazorHero.CleanArchitecture.sln
+++ b/BlazorHero.CleanArchitecture.sln
@@ -45,6 +45,10 @@ Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "BlazorHero.CleanArchitectur
 EndProject
 Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "BlazorHero.CleanArchitecture.Infrastructure.Shared", "BlazorHero.CleanArchitecture.Infrastructure.Shared\BlazorHero.CleanArchitecture.Infrastructure.Shared.csproj", "{BFAD2E2A-8C7C-4357-9C81-D2ECDEEFC0F1}"
 EndProject
+Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "Client.InServerMode", "Client.InServerMode", "{98DF7C24-DF80-4840-9E93-AA3443314949}"
+EndProject
+Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "BlazorHero.CleanArchitecture.Client.InServerMode", "BlazorHero.CleanArchitecture\Client.InServerMode\BlazorHero.CleanArchitecture.Client.InServerMode.csproj", "{A5752C42-8C2B-4224-A3EC-5045B92ED49E}"
+EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
 		Debug|Any CPU = Debug|Any CPU
@@ -83,6 +87,10 @@ Global
 		{BFAD2E2A-8C7C-4357-9C81-D2ECDEEFC0F1}.Debug|Any CPU.Build.0 = Debug|Any CPU
 		{BFAD2E2A-8C7C-4357-9C81-D2ECDEEFC0F1}.Release|Any CPU.ActiveCfg = Release|Any CPU
 		{BFAD2E2A-8C7C-4357-9C81-D2ECDEEFC0F1}.Release|Any CPU.Build.0 = Release|Any CPU
+		{A5752C42-8C2B-4224-A3EC-5045B92ED49E}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{A5752C42-8C2B-4224-A3EC-5045B92ED49E}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{A5752C42-8C2B-4224-A3EC-5045B92ED49E}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{A5752C42-8C2B-4224-A3EC-5045B92ED49E}.Release|Any CPU.Build.0 = Release|Any CPU
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE
@@ -102,6 +110,8 @@ Global
 		{34B1D3CA-BBB6-449E-82A7-DF2BDBC9838F} = {0317DF35-F5C5-4986-BA37-40C28554268F}
 		{6B3A1D03-E35E-4579-A24A-E3343D024B4B} = {885BB018-5B07-4038-B061-71B70188933B}
 		{BFAD2E2A-8C7C-4357-9C81-D2ECDEEFC0F1} = {39A93E2F-51DE-47C0-93AF-A24561630C18}
+		{98DF7C24-DF80-4840-9E93-AA3443314949} = {FFBDEDF1-17E2-4F72-AE03-C99B44D8BFCA}
+		{A5752C42-8C2B-4224-A3EC-5045B92ED49E} = {98DF7C24-DF80-4840-9E93-AA3443314949}
 	EndGlobalSection
 	GlobalSection(ExtensibilityGlobals) = postSolution
 		SolutionGuid = {ED3E6669-AEC5-4A3B-9E57-2A81DE87BAAF}

--- a/BlazorHero.CleanArchitecture/Client.InServerMode/BlazorHero.CleanArchitecture.Client.InServerMode.csproj
+++ b/BlazorHero.CleanArchitecture/Client.InServerMode/BlazorHero.CleanArchitecture.Client.InServerMode.csproj
@@ -1,0 +1,12 @@
+﻿<Project Sdk="Microsoft.NET.Sdk.Web">
+
+  <PropertyGroup>
+    <TargetFramework>net5.0</TargetFramework>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <ProjectReference Include="..\..\BlazorHero.CleanArchitecture.Shared\BlazorHero.CleanArchitecture.Shared.csproj" />
+    <ProjectReference Include="..\Client\BlazorHero.CleanArchitecture.Client.csproj" />
+  </ItemGroup>
+
+</Project>

--- a/BlazorHero.CleanArchitecture/Client.InServerMode/Extensions/ClaimsPrincipalExtensions.cs
+++ b/BlazorHero.CleanArchitecture/Client.InServerMode/Extensions/ClaimsPrincipalExtensions.cs
@@ -1,0 +1,22 @@
+﻿using System.Security.Claims;
+
+namespace BlazorHero.CleanArchitecture.Client.Extensions
+{
+    internal static class ClaimsPrincipalExtensions
+    {
+        internal static string GetEmail(this ClaimsPrincipal claimsPrincipal)
+            => claimsPrincipal.FindFirstValue(ClaimTypes.Email);
+
+        internal static string GetFirstName(this ClaimsPrincipal claimsPrincipal)
+            => claimsPrincipal.FindFirstValue(ClaimTypes.Name);
+
+        internal static string GetLastName(this ClaimsPrincipal claimsPrincipal)
+            => claimsPrincipal.FindFirstValue(ClaimTypes.Surname);
+
+        internal static string GetPhoneNumber(this ClaimsPrincipal claimsPrincipal)
+            => claimsPrincipal.FindFirstValue(ClaimTypes.MobilePhone);
+
+        internal static string GetUserId(this ClaimsPrincipal claimsPrincipal)
+           => claimsPrincipal.FindFirstValue(ClaimTypes.NameIdentifier);
+    }
+}

--- a/BlazorHero.CleanArchitecture/Client.InServerMode/Extensions/HubExtensions.cs
+++ b/BlazorHero.CleanArchitecture/Client.InServerMode/Extensions/HubExtensions.cs
@@ -1,0 +1,19 @@
+﻿using Microsoft.AspNetCore.Components;
+using Microsoft.AspNetCore.SignalR.Client;
+
+namespace BlazorHero.CleanArchitecture.Client.InServerMode.Extensions
+{
+    public static class HubExtensions
+    {
+        public static HubConnection TryInitialize(this HubConnection hubConnection, NavigationManager navigationManager)
+        {
+            if (hubConnection == null)
+            {
+                hubConnection = new HubConnectionBuilder()
+                                  .WithUrl(navigationManager.ToAbsoluteUri("/signalRHub"))
+                                  .Build();
+            }
+            return hubConnection;
+        }
+    }
+}

--- a/BlazorHero.CleanArchitecture/Client.InServerMode/Extensions/ServiceCollectionExtensions.cs
+++ b/BlazorHero.CleanArchitecture/Client.InServerMode/Extensions/ServiceCollectionExtensions.cs
@@ -1,0 +1,105 @@
+﻿using Blazored.LocalStorage;
+using BlazorHero.CleanArchitecture.Client.Infrastructure.Authentication;
+using BlazorHero.CleanArchitecture.Client.Infrastructure.Managers;
+using BlazorHero.CleanArchitecture.Client.Infrastructure.Managers.Preferences;
+using BlazorHero.CleanArchitecture.Shared.Constants.Permission;
+using Microsoft.AspNetCore.Authorization;
+using Microsoft.AspNetCore.Components.Authorization;
+using Microsoft.Extensions.Configuration;
+using Microsoft.Extensions.DependencyInjection;
+using MudBlazor;
+using MudBlazor.Services;
+using System;
+using System.Globalization;
+using System.Linq;
+using System.Net.Http;
+using System.Reflection;
+using Toolbelt.Blazor.Extensions.DependencyInjection;
+
+namespace BlazorHero.CleanArchitecture.Client.InServerMode.Extensions
+{
+    public static class ServiceCollectionExtensions
+    {
+        private const string ClientName = "BlazorHero.API";
+
+        public static IServiceCollection AddClientServices(this IServiceCollection services,  IConfiguration configuration)
+        {
+            services
+                .AddLocalization(options =>
+                {
+                    options.ResourcesPath = "Resources";
+                })
+                .AddAuthorizationCore(options =>
+                {
+                    RegisterPermissionClaims(options);
+                })
+                .AddBlazoredLocalStorage()
+                .AddMudServices(configuration =>
+                {
+                    configuration.SnackbarConfiguration.PositionClass = Defaults.Classes.Position.BottomRight;
+                    configuration.SnackbarConfiguration.HideTransitionDuration = 100;
+                    configuration.SnackbarConfiguration.ShowTransitionDuration = 100;
+                    configuration.SnackbarConfiguration.VisibleStateDuration = 3000;
+                    configuration.SnackbarConfiguration.ShowCloseIcon = false;
+                })
+                .AddAutoMapper(AppDomain.CurrentDomain.GetAssemblies())
+                .AddScoped<ClientPreferenceManager>()
+                .AddScoped<BlazorHeroStateProvider>()
+                .AddScoped<AuthenticationStateProvider, BlazorHeroStateProvider>()
+                .AddManagers()
+                .AddTransient<AuthenticationHeaderHandler>()
+                .AddScoped(sp => sp
+                    .GetRequiredService<IHttpClientFactory>()
+                    .CreateClient(ClientName).EnableIntercept(sp))
+                .AddHttpClient(ClientName, client =>
+                {
+                    client.DefaultRequestHeaders.AcceptLanguage.Clear();
+                    client.DefaultRequestHeaders.AcceptLanguage.ParseAdd(CultureInfo.DefaultThreadCurrentCulture?.TwoLetterISOLanguageName);
+                    client.BaseAddress = new Uri(configuration.GetValue<string>("ServerURI"));
+                })
+                .AddHttpMessageHandler<AuthenticationHeaderHandler>();
+            services.AddHttpClientInterceptor();
+            services.AddSignalR();
+
+            return services;
+        }
+
+        public static IServiceCollection AddManagers(this IServiceCollection services)
+        {
+            var managers = typeof(IManager);
+
+            var types = managers
+                .Assembly
+                .GetExportedTypes()
+                .Where(t => t.IsClass && !t.IsAbstract)
+                .Select(t => new
+                {
+                    Service = t.GetInterface($"I{t.Name}"),
+                    Implementation = t
+                })
+                .Where(t => t.Service != null);
+
+            foreach (var type in types)
+            {
+                if (managers.IsAssignableFrom(type.Service))
+                {
+                    services.AddTransient(type.Service, type.Implementation);
+                }
+            }
+
+            return services;
+        }
+
+        private static void RegisterPermissionClaims(AuthorizationOptions options)
+        {
+            foreach (var prop in typeof(Permissions).GetNestedTypes().SelectMany(c => c.GetFields(BindingFlags.Public | BindingFlags.Static | BindingFlags.FlattenHierarchy)))
+            {
+                var propertyValue = prop.GetValue(null);
+                if (propertyValue is not null)
+                {
+                    options.AddPolicy(propertyValue.ToString(), policy => policy.RequireClaim(ApplicationClaimTypes.Permission, propertyValue.ToString()));
+                }
+            }
+        }
+    }
+}

--- a/BlazorHero.CleanArchitecture/Client.InServerMode/Hubs/SignalRHub.cs
+++ b/BlazorHero.CleanArchitecture/Client.InServerMode/Hubs/SignalRHub.cs
@@ -1,0 +1,46 @@
+﻿using BlazorHero.CleanArchitecture.Application.Models.Chat;
+using BlazorHero.CleanArchitecture.Shared.Constants.Application;
+using Microsoft.AspNetCore.SignalR;
+using System.Threading.Tasks;
+using BlazorHero.CleanArchitecture.Application.Interfaces.Chat;
+
+namespace BlazorHero.CleanArchitecture.Client.InServerMode.Hubs
+{
+    public class SignalRHub : Hub
+    {
+        public async Task OnConnectAsync(string userId)
+        {
+            await Clients.All.SendAsync(ApplicationConstants.SignalR.ConnectUser, userId);
+        }
+
+        public async Task OnDisconnectAsync(string userId)
+        {
+            await Clients.All.SendAsync(ApplicationConstants.SignalR.DisconnectUser, userId);
+        }
+
+        public async Task OnChangeRolePermissions(string userId, string roleId)
+        {
+            await Clients.All.SendAsync(ApplicationConstants.SignalR.LogoutUsersByRole, userId, roleId);
+        }
+
+        public async Task SendMessageAsync(ChatHistory<IChatUser> chatHistory, string userName)
+        {
+            await Clients.All.SendAsync(ApplicationConstants.SignalR.ReceiveMessage, chatHistory, userName);
+        }
+
+        public async Task ChatNotificationAsync(string message, string receiverUserId, string senderUserId)
+        {
+            await Clients.All.SendAsync(ApplicationConstants.SignalR.ReceiveChatNotification, message, receiverUserId, senderUserId);
+        }
+
+        public async Task UpdateDashboardAsync()
+        {
+            await Clients.All.SendAsync(ApplicationConstants.SignalR.ReceiveUpdateDashboard);
+        }
+
+        public async Task RegenerateTokensAsync()
+        {
+            await Clients.All.SendAsync(ApplicationConstants.SignalR.ReceiveRegenerateTokens);
+        }
+    }
+}

--- a/BlazorHero.CleanArchitecture/Client.InServerMode/Pages/_Host.cshtml
+++ b/BlazorHero.CleanArchitecture/Client.InServerMode/Pages/_Host.cshtml
@@ -1,0 +1,35 @@
+﻿@page "/"
+@namespace BlazorHero.CleanArchitecture.Client.InServerMode.Pages
+@addTagHelper *, Microsoft.AspNetCore.Mvc.TagHelpers
+
+
+<!DOCTYPE html>
+<html>
+
+<head>
+    <meta charset="utf-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0, maximum-scale=1.0, user-scalable=no" />
+    <title>BlazorHero - Clean Architecture - Blazor Server Mode</title>
+    <base href="/" />
+    <link href="https://fonts.googleapis.com/css2?family=Montserrat:wght@400;500;600;700&display=swap" rel="stylesheet">
+    <link href="https://fonts.googleapis.com/css?family=Roboto:300,400,500,700&display=swap" rel="stylesheet" />
+    <link href="_content/MudBlazor/MudBlazor.min.css" rel="stylesheet" />
+    <link href="css/loader.css" rel="stylesheet" />
+</head>
+
+<body>
+
+    <component type="typeof(BlazorHero.CleanArchitecture.Client.App)" render-mode="Server" />
+
+    <div id="blazor-error-ui">
+        An unhandled error has occurred.
+        <a href="" class="reload">Reload</a>
+        <a class="dismiss">🗙</a>
+    </div>
+    <script src="js/scroll.js"></script>
+    <script src="js/sounds.js"></script>
+    <script src="js/file.js"></script>
+    <script src="_framework/blazor.server.js"></script>
+    <script src="_content/MudBlazor/MudBlazor.min.js"></script>
+</body>
+</html>

--- a/BlazorHero.CleanArchitecture/Client.InServerMode/Program.cs
+++ b/BlazorHero.CleanArchitecture/Client.InServerMode/Program.cs
@@ -1,0 +1,26 @@
+using Microsoft.AspNetCore.Hosting;
+using Microsoft.Extensions.Configuration;
+using Microsoft.Extensions.Hosting;
+using Microsoft.Extensions.Logging;
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Threading.Tasks;
+
+namespace BlazorHero.CleanArchitecture.Client.InServerMode
+{
+    public class Program
+    {
+        public static void Main(string[] args)
+        {
+            CreateHostBuilder(args).Build().Run();
+        }
+
+        public static IHostBuilder CreateHostBuilder(string[] args) =>
+            Host.CreateDefaultBuilder(args)
+                .ConfigureWebHostDefaults(webBuilder =>
+                {
+                    webBuilder.UseStartup<Startup>();
+                });
+    }
+}

--- a/BlazorHero.CleanArchitecture/Client.InServerMode/Properties/launchSettings.json
+++ b/BlazorHero.CleanArchitecture/Client.InServerMode/Properties/launchSettings.json
@@ -1,0 +1,28 @@
+{
+  "iisSettings": {
+    "windowsAuthentication": false,
+    "anonymousAuthentication": true,
+    "iisExpress": {
+      "applicationUrl": "http://localhost:39544",
+      "sslPort": 44359
+    }
+  },
+  "profiles": {
+    "IIS Express": {
+      "commandName": "IISExpress",
+      "launchBrowser": true,
+      "environmentVariables": {
+        "ASPNETCORE_ENVIRONMENT": "Development"
+      }
+    },
+    "BlazorHero.CleanArchitecture.Client.InServerMode": {
+      "commandName": "Project",
+      "dotnetRunMessages": "true",
+      "launchBrowser": true,
+      "applicationUrl": "https://localhost:5003;http://localhost:5002",
+      "environmentVariables": {
+        "ASPNETCORE_ENVIRONMENT": "Development"
+      }
+    }
+  }
+}

--- a/BlazorHero.CleanArchitecture/Client.InServerMode/Startup.cs
+++ b/BlazorHero.CleanArchitecture/Client.InServerMode/Startup.cs
@@ -1,0 +1,79 @@
+using Blazored.LocalStorage;
+using BlazorHero.CleanArchitecture.Client.Infrastructure.Authentication;
+using BlazorHero.CleanArchitecture.Client.Infrastructure.Managers;
+using BlazorHero.CleanArchitecture.Client.Infrastructure.Managers.Preferences;
+using BlazorHero.CleanArchitecture.Client.InServerMode.Extensions;
+using BlazorHero.CleanArchitecture.Shared.Constants.Permission;
+using Microsoft.AspNetCore.Authorization;
+using Microsoft.AspNetCore.Builder;
+using Microsoft.AspNetCore.Components;
+using Microsoft.AspNetCore.Components.Authorization;
+using Microsoft.AspNetCore.Hosting;
+using Microsoft.AspNetCore.HttpsPolicy;
+using Microsoft.Extensions.Configuration;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Hosting;
+using MudBlazor;
+using MudBlazor.Services;
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Net.Http;
+using System.Threading.Tasks;
+using Toolbelt.Blazor.Extensions.DependencyInjection;
+using BlazorHero.CleanArchitecture.Client.InServerMode.Hubs;
+
+namespace BlazorHero.CleanArchitecture.Client.InServerMode
+{
+    public class Startup
+    {
+        public Startup(IConfiguration configuration)
+        {
+            Configuration = configuration;
+        }
+
+        public IConfiguration Configuration { get; }
+
+        // This method gets called by the runtime. Use this method to add services to the container.
+        // For more information on how to configure your application, visit https://go.microsoft.com/fwlink/?LinkID=398940
+        public void ConfigureServices(IServiceCollection services)
+        {
+            services.AddRazorPages();
+            services.AddServerSideBlazor();
+            services.AddClientServices(Configuration);
+        }
+
+        // This method gets called by the runtime. Use this method to configure the HTTP request pipeline.
+        public void Configure(IApplicationBuilder app, IWebHostEnvironment env)
+        {
+            if (env.IsDevelopment())
+            {
+                app.UseDeveloperExceptionPage();
+            }
+            else
+            {
+                app.UseExceptionHandler("/Error");
+                // The default HSTS value is 30 days. You may want to change this for production scenarios, see https://aka.ms/aspnetcore-hsts.
+                app.UseHsts();
+            }
+
+            app.UseHttpsRedirection();
+            app.UseStaticFiles();
+
+            app.UseRouting();
+
+            app.UseAuthentication();
+            app.UseAuthorization();
+
+            app.UseEndpoints(endpoints =>
+            {
+                endpoints.MapRazorPages();
+                endpoints.MapControllers();
+
+                endpoints.MapBlazorHub();
+                endpoints.MapFallbackToPage("/_Host");
+                endpoints.MapHub<SignalRHub>("/signalRHub");
+            });
+        }
+    }
+}

--- a/BlazorHero.CleanArchitecture/Client.InServerMode/appsettings.Development.json
+++ b/BlazorHero.CleanArchitecture/Client.InServerMode/appsettings.Development.json
@@ -1,0 +1,10 @@
+{
+  "DetailedErrors": true,
+  "Logging": {
+    "LogLevel": {
+      "Default": "Information",
+      "Microsoft": "Warning",
+      "Microsoft.Hosting.Lifetime": "Information"
+    }
+  }
+}

--- a/BlazorHero.CleanArchitecture/Client.InServerMode/appsettings.json
+++ b/BlazorHero.CleanArchitecture/Client.InServerMode/appsettings.json
@@ -1,0 +1,11 @@
+{
+  "Logging": {
+    "LogLevel": {
+      "Default": "Information",
+      "Microsoft": "Warning",
+      "Microsoft.Hosting.Lifetime": "Information"
+    }
+  },
+  "ServerURI": "https://localhost:44398/",
+  "AllowedHosts": "*"
+}


### PR DESCRIPTION
…at uses the existing Client UI code.

HOW TO USE:
To run client UI in Blazor Server mode -
   (1) Right-click on solution
   (2) Click on 'Set startup projects'
   (3) Select 'Multiple startup projects option
   (4) Set the Actions for *.Server and *.Client.InServerMode to 'Startup'

NOTES:
 (1) This change is based on the article in http://www.appvnext.com/blog/2020/2/2/reuse-blazor-wasm-ui-in-blazor-server.
 (2)  I had to make one change to get auth to work in blazor server mode in .\BlazorHero.CleanArchitecture.Client.Infrastructure\Authentication\AuthenticationHeaderHandler.cs.
      Trying to avoid changed to existing code has led to some duplication in the Extensions code. If this indeed checked in and people find it useful, we could look at refactoring these at some point.

KNOWN ISSUES:
  (1) The Swagger and Hangfire links on the sidebar do not work when UI is running on the server (as they are now running on a different port)