### PR TITLE
Fix ParseBase64WithoutPadding problem with illegal characters

### DIFF
--- a/src/Client.Infrastructure/Authentication/BlazorHeroStateProvider.cs
+++ b/src/Client.Infrastructure/Authentication/BlazorHeroStateProvider.cs
@@ -111,14 +111,10 @@ namespace BlazorHero.CleanArchitecture.Client.Infrastructure.Authentication
             return claims;
         }
 
-        private byte[] ParseBase64WithoutPadding(string base64)
+        private byte[] ParseBase64WithoutPadding(string payload)
         {
-            switch (base64.Length % 4)
-            {
-                case 2: base64 += "=="; break;
-                case 3: base64 += "="; break;
-            }
-
+            payload = payload.Trim().Replace('-', '+').Replace('_', '/');
+            var base64 = payload.PadRight(payload.Length + (4 - payload.Length % 4) % 4, '=');
             return Convert.FromBase64String(base64);
         }
     }


### PR DESCRIPTION
When the jwt token is split to get the base64 encoded string that represents the JWT claims, it can happen that the base64 encoded string contain illegal characters (e.g underscore or minus).
In those cases an error occurs : 

> The input is not a valid Base-64 string as it contains a non-base 64 character, more than two padding characters, or an illegal character among the padding character

 
the fix allows claims that contain an illegal character  among the padding characters