### PR TITLE
Generating an endpoint graph from an integration test

### DIFF
--- a/BlazorHero.CleanArchitecture.sln
+++ b/BlazorHero.CleanArchitecture.sln
@@ -47,6 +47,8 @@ Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Infrastructure.Shared", "sr
 EndProject
 Project("{E53339B2-1760-4266-BCC7-CA923CBCF16C}") = "docker-compose", "docker-compose.dcproj", "{161B234C-6018-4CE5-86B2-0EA95A53982D}"
 EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "ApiRoutesTest", "src\Tests\ApiRoutesTest\ApiRoutesTest.csproj", "{3E1BDD60-0FA1-4085-8AEB-614715911373}"
+EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
 		Debug|Any CPU = Debug|Any CPU
@@ -88,6 +90,10 @@ Global
 		{161B234C-6018-4CE5-86B2-0EA95A53982D}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
 		{161B234C-6018-4CE5-86B2-0EA95A53982D}.Release|Any CPU.ActiveCfg = Release|Any CPU
 		{161B234C-6018-4CE5-86B2-0EA95A53982D}.Release|Any CPU.Build.0 = Release|Any CPU
+		{3E1BDD60-0FA1-4085-8AEB-614715911373}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{3E1BDD60-0FA1-4085-8AEB-614715911373}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{3E1BDD60-0FA1-4085-8AEB-614715911373}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{3E1BDD60-0FA1-4085-8AEB-614715911373}.Release|Any CPU.Build.0 = Release|Any CPU
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE
@@ -107,6 +113,7 @@ Global
 		{34B1D3CA-BBB6-449E-82A7-DF2BDBC9838F} = {0317DF35-F5C5-4986-BA37-40C28554268F}
 		{6B3A1D03-E35E-4579-A24A-E3343D024B4B} = {885BB018-5B07-4038-B061-71B70188933B}
 		{BFAD2E2A-8C7C-4357-9C81-D2ECDEEFC0F1} = {39A93E2F-51DE-47C0-93AF-A24561630C18}
+		{3E1BDD60-0FA1-4085-8AEB-614715911373} = {1D491AAE-7A45-4B6B-9E3B-F8F3F0EFDED5}
 	EndGlobalSection
 	GlobalSection(ExtensibilityGlobals) = postSolution
 		SolutionGuid = {ED3E6669-AEC5-4A3B-9E57-2A81DE87BAAF}

--- a/src/Tests/ApiRoutesTest/ApiRoutesTest.csproj
+++ b/src/Tests/ApiRoutesTest/ApiRoutesTest.csproj
@@ -1,4 +1,4 @@
-<Project Sdk="Microsoft.NET.Sdk">
+<Project Sdk="Microsoft.NET.Sdk.Web">
 
   <PropertyGroup>
     <TargetFramework>net5.0</TargetFramework>

--- a/src/Tests/ApiRoutesTest/ApiRoutesTest.csproj
+++ b/src/Tests/ApiRoutesTest/ApiRoutesTest.csproj
@@ -1,0 +1,27 @@
+<Project Sdk="Microsoft.NET.Sdk">
+
+  <PropertyGroup>
+    <TargetFramework>net5.0</TargetFramework>
+
+    <IsPackable>false</IsPackable>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <PackageReference Include="Microsoft.AspNetCore.Mvc.Testing" Version="5.0.10" />
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="16.7.1" />
+    <PackageReference Include="xunit" Version="2.4.1" />
+    <PackageReference Include="xunit.runner.visualstudio" Version="2.4.3">
+      <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
+      <PrivateAssets>all</PrivateAssets>
+    </PackageReference>
+    <PackageReference Include="coverlet.collector" Version="1.3.0">
+      <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
+      <PrivateAssets>all</PrivateAssets>
+    </PackageReference>
+  </ItemGroup>
+
+  <ItemGroup>
+    <ProjectReference Include="..\..\Server\Server.csproj" />
+  </ItemGroup>
+
+</Project>

--- a/src/Tests/ApiRoutesTest/GenerateGraphTest.cs
+++ b/src/Tests/ApiRoutesTest/GenerateGraphTest.cs
@@ -1,0 +1,47 @@
+using BlazorHero.CleanArchitecture.Server;
+using Microsoft.AspNetCore.Mvc.Testing;
+using Microsoft.AspNetCore.Routing;
+using Microsoft.AspNetCore.Routing.Internal;
+using Microsoft.Extensions.DependencyInjection;
+using System;
+using System.IO;
+using Xunit;
+using Xunit.Abstractions;
+
+namespace ApiRoutesTest
+{
+    public class GenerateGraphTest
+        : IClassFixture<WebApplicationFactory<Startup>>
+    {
+        // Inject the factory and the output helper
+        private readonly WebApplicationFactory<Startup> _factory;
+        private readonly ITestOutputHelper _output;
+
+        public GenerateGraphTest(
+        WebApplicationFactory<Startup> factory, ITestOutputHelper output)
+        {
+            _factory = factory;
+            _output = output;
+        }
+
+        [Fact]
+        public void GenerateGraph()
+        {
+            // fetch the required services from the root container of the app
+            var graphWriter = _factory.Services.GetRequiredService<DfaGraphWriter>();
+            var endpointData = _factory.Services.GetRequiredService<EndpointDataSource>();
+
+            Directory.CreateDirectory("Files");
+
+            // build the graph
+            using (var sw = new StringWriter())
+            {
+                graphWriter.Write(endpointData, sw);
+                var graph = sw.ToString();
+
+                // write the graph to the test output
+                _output.WriteLine(graph);
+            }
+        }
+    }
+}

--- a/src/Tests/ApiRoutesTest/Properties/launchSettings.json
+++ b/src/Tests/ApiRoutesTest/Properties/launchSettings.json
@@ -1,0 +1,27 @@
+{
+  "iisSettings": {
+    "windowsAuthentication": false,
+    "anonymousAuthentication": true,
+    "iisExpress": {
+      "applicationUrl": "http://localhost:52434/",
+      "sslPort": 44356
+    }
+  },
+  "profiles": {
+    "IIS Express": {
+      "commandName": "IISExpress",
+      "launchBrowser": true,
+      "environmentVariables": {
+        "ASPNETCORE_ENVIRONMENT": "Development"
+      }
+    },
+    "ApiRoutesTest": {
+      "commandName": "Project",
+      "launchBrowser": true,
+      "environmentVariables": {
+        "ASPNETCORE_ENVIRONMENT": "Development"
+      },
+      "applicationUrl": "https://localhost:5001;http://localhost:5000"
+    }
+  }
+}


### PR DESCRIPTION
Run test as debug mode "Debug Test" you will face an error from BlazorHero.CleanArchitecture.Server that say System can not find "Files" directory. it must be fix.
but for now, you can just make Files directory inside of ApiRoutesTest\bin\Debug\net5.0
Then run the test and click on the result from test explorer.
right click and copy all
then past it to https://dreampuf.github.io/GraphvizOnline/
