### PR TITLE
Issue #319

### DIFF
--- a/src/Server/Extensions/ServiceCollectionExtensions.cs
+++ b/src/Server/Extensions/ServiceCollectionExtensions.cs
@@ -267,7 +267,7 @@ namespace BlazorHero.CleanArchitecture.Server.Extensions
         internal static IServiceCollection AddJwtAuthentication(
             this IServiceCollection services, AppConfiguration config)
         {
-            var key = Encoding.ASCII.GetBytes(config.Secret);
+            var key = Encoding.UTF8.GetBytes(config.Secret);
             services
                 .AddAuthentication(authentication =>
                 {


### PR DESCRIPTION
Under Infrastructure -> Services -> Identity -> IdentityService.cs the method GetSigningCredentials() uses Encoding.UTF8

But under Server->Extensions->ServiceCollectionExtensions.cs the method AddJwtAuthentication() was using Encoding.ASCII