### PR TITLE
Feature/dockerfile migrate to dotnet6

### DIFF
--- a/BlazorHero.CleanArchitecture.sln
+++ b/BlazorHero.CleanArchitecture.sln
@@ -1,7 +1,7 @@
 ﻿
 Microsoft Visual Studio Solution File, Format Version 12.00
-# Visual Studio Version 16
-VisualStudioVersion = 16.0.30804.86
+# Visual Studio Version 17
+VisualStudioVersion = 17.0.32112.339
 MinimumVisualStudioVersion = 10.0.40219.1
 Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "Source", "Source", "{0317DF35-F5C5-4986-BA37-40C28554268F}"
 EndProject
@@ -86,6 +86,7 @@ Global
 		{BFAD2E2A-8C7C-4357-9C81-D2ECDEEFC0F1}.Release|Any CPU.ActiveCfg = Release|Any CPU
 		{BFAD2E2A-8C7C-4357-9C81-D2ECDEEFC0F1}.Release|Any CPU.Build.0 = Release|Any CPU
 		{161B234C-6018-4CE5-86B2-0EA95A53982D}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{161B234C-6018-4CE5-86B2-0EA95A53982D}.Debug|Any CPU.Build.0 = Debug|Any CPU
 		{161B234C-6018-4CE5-86B2-0EA95A53982D}.Release|Any CPU.ActiveCfg = Release|Any CPU
 		{161B234C-6018-4CE5-86B2-0EA95A53982D}.Release|Any CPU.Build.0 = Release|Any CPU
 	EndGlobalSection

--- a/src/Server/Dockerfile
+++ b/src/Server/Dockerfile
@@ -1,13 +1,13 @@
 #See https://aka.ms/containerfastmode to understand how Visual Studio uses this Dockerfile to build your images for faster debugging.
 
-FROM mcr.microsoft.com/dotnet/aspnet:5.0 AS base
+FROM mcr.microsoft.com/dotnet/aspnet:6.0 AS base
 ENV ASPNETCORE_URLS=https://+:5005;http://+:5006
 WORKDIR /app
 EXPOSE 5005
 EXPOSE 5006
 
-FROM mcr.microsoft.com/dotnet/sdk:5.0 AS build
-WORKDIR /
+FROM mcr.microsoft.com/dotnet/sdk:6.0 AS build
+WORKDIR /src
 COPY ["src/Server/Server.csproj", "src/Server/"]
 COPY ["src/Application/Application.csproj", "src/Application/"]
 COPY ["src/Domain/Domain.csproj", "src/Domain/"]
@@ -18,7 +18,7 @@ COPY ["src/Client/Client.csproj", "src/Client/"]
 COPY ["src/Client.Infrastructure/Client.Infrastructure.csproj", "src/Client.Infrastructure/"]
 RUN dotnet restore "src/Server/Server.csproj" --disable-parallel
 COPY . .
-WORKDIR "src/Server"
+WORKDIR "/src/src/Server"
 RUN dotnet build "Server.csproj" -c Release -o /app/build
 
 FROM build AS publish
@@ -27,6 +27,4 @@ RUN dotnet publish "Server.csproj" -c Release -o /app/publish
 FROM base AS final
 WORKDIR /app
 COPY --from=publish /app/publish .
-WORKDIR /app/Files
-WORKDIR /app
 ENTRYPOINT ["dotnet", "BlazorHero.CleanArchitecture.Server.dll"]


### PR DESCRIPTION
Was tinkering around with my privately forked repo and noticed this was missing from the previous .net 6 migration pull request.

The solution file changes are to account for the fact the .net 6 only runs in 2022, not 2019 :)